### PR TITLE
Soft delete de produtos e consulta de produtos por categoria

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -17,6 +17,7 @@ CREATE TABLE IF NOT EXISTS produto (
     descricao_produto VARCHAR(255),
     preco_produto DECIMAL(10, 2) NOT NULL,
     id_categoria INT NOT NULL,
+    ativo TINYINT(1) NOT NULL DEFAULT 1,
     PRIMARY KEY (id_produto),
     FOREIGN KEY (id_categoria) REFERENCES categoria (id_categoria)
 );

--- a/src/main/java/br/com/fiap/lanchonete/application/adapters/controllers/ProdutoController.java
+++ b/src/main/java/br/com/fiap/lanchonete/application/adapters/controllers/ProdutoController.java
@@ -1,12 +1,20 @@
 package br.com.fiap.lanchonete.application.adapters.controllers;
 
-import br.com.fiap.lanchonete.domain.adapters.services.ProdutoServiceImpl;
-import br.com.fiap.lanchonete.domain.dtos.ProdutoDto;
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
+import br.com.fiap.lanchonete.domain.adapters.services.ProdutoServiceImpl;
+import br.com.fiap.lanchonete.domain.dtos.ProdutoDto;
 
 @RestController
 @RequestMapping("/lanchonete/v1/produtos")
@@ -28,14 +36,22 @@ public class ProdutoController {
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
+    @GetMapping("/categoria/{idCategoria}")
+    public ResponseEntity<List<ProdutoDto>> getProdutosByCategoria(@PathVariable Integer idCategoria) {
+        return ResponseEntity.ok(produtoServiceImpl.findByCategoria(idCategoria));
+    }
+
     @GetMapping
     public ResponseEntity<List<ProdutoDto>> getAllProdutos() {
-        List<ProdutoDto> produtos = produtoServiceImpl.findAll();
+        List<ProdutoDto> produtos = produtoServiceImpl.findAllByAtivoTrue();
         return ResponseEntity.ok(produtos);
     }
 
     @DeleteMapping("/{idProduto}")
     public ResponseEntity<Void> deleteProdutoById(@PathVariable String idProduto) {
+        if (produtoServiceImpl.findByIdProduto(idProduto).isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
         produtoServiceImpl.deleteByIdProduto(idProduto);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/br/com/fiap/lanchonete/domain/adapters/services/ProdutoServiceImpl.java
+++ b/src/main/java/br/com/fiap/lanchonete/domain/adapters/services/ProdutoServiceImpl.java
@@ -3,6 +3,8 @@ package br.com.fiap.lanchonete.domain.adapters.services;
 import br.com.fiap.lanchonete.domain.dtos.ProdutoDto;
 import br.com.fiap.lanchonete.domain.ports.interfaces.ProdutoServicePort;
 import br.com.fiap.lanchonete.domain.ports.repositories.ProdutoRepositoryPort;
+import br.com.fiap.lanchonete.infrastructure.adapters.entity.CategoriaEntity;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -29,6 +31,17 @@ public class ProdutoServiceImpl implements ProdutoServicePort {
     @Override
     public List<ProdutoDto> findAll() {
         return produtoRepository.findAll();
+    }
+
+    @Override
+    public List<ProdutoDto> findAllByAtivoTrue() {
+        return produtoRepository.findAllByAtivoTrue();
+    }
+
+    @Override
+    public List<ProdutoDto> findByCategoria(Integer idCategoria) {
+        return produtoRepository.findAllByAtivoTrueAndCategoria(
+                CategoriaEntity.builder().idCategoria(Optional.ofNullable(idCategoria).orElse(0)).build());
     }
 
     @Override

--- a/src/main/java/br/com/fiap/lanchonete/domain/ports/interfaces/ProdutoServicePort.java
+++ b/src/main/java/br/com/fiap/lanchonete/domain/ports/interfaces/ProdutoServicePort.java
@@ -7,8 +7,16 @@ import java.util.Optional;
 
 public interface ProdutoServicePort {
     ProdutoDto save(ProdutoDto produtoDto);
+
     Optional<ProdutoDto> findByIdProduto(String idProduto);
+
     List<ProdutoDto> findAll();
+
     void deleteByIdProduto(String idProdutoDto);
+
     ProdutoDto saveOrUpdate(ProdutoDto produtoDto);
+
+    List<ProdutoDto> findAllByAtivoTrue();
+
+    List<ProdutoDto> findByCategoria(Integer idCategoria);
 }

--- a/src/main/java/br/com/fiap/lanchonete/domain/ports/repositories/ProdutoRepositoryPort.java
+++ b/src/main/java/br/com/fiap/lanchonete/domain/ports/repositories/ProdutoRepositoryPort.java
@@ -1,14 +1,21 @@
 package br.com.fiap.lanchonete.domain.ports.repositories;
 
-import br.com.fiap.lanchonete.domain.dtos.ProdutoDto;
-
 import java.util.List;
 import java.util.Optional;
 
+import br.com.fiap.lanchonete.domain.dtos.ProdutoDto;
+import br.com.fiap.lanchonete.infrastructure.adapters.entity.CategoriaEntity;
+
 public interface ProdutoRepositoryPort {
     ProdutoDto save(ProdutoDto produtoDto); // Create and Update
+
     Optional<ProdutoDto> findByIdProduto(String idProduto); // Read
+
     List<ProdutoDto> findAll(); // Read All
 
+    List<ProdutoDto> findAllByAtivoTrue(); // Read all ativo = true
+
     void deleteByIdProduto(String idProduto);
+
+    List<ProdutoDto> findAllByAtivoTrueAndCategoria(CategoriaEntity categoria);
 }

--- a/src/main/java/br/com/fiap/lanchonete/infrastructure/adapters/entity/CategoriaEntity.java
+++ b/src/main/java/br/com/fiap/lanchonete/infrastructure/adapters/entity/CategoriaEntity.java
@@ -1,13 +1,17 @@
 package br.com.fiap.lanchonete.infrastructure.adapters.entity;
 
-
 import jakarta.persistence.*;
-
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 @Entity
 @Table(name = "categoria")
 public class CategoriaEntity {

--- a/src/main/java/br/com/fiap/lanchonete/infrastructure/adapters/entity/ProdutoEntity.java
+++ b/src/main/java/br/com/fiap/lanchonete/infrastructure/adapters/entity/ProdutoEntity.java
@@ -1,12 +1,10 @@
 package br.com.fiap.lanchonete.infrastructure.adapters.entity;
 
-
 import jakarta.persistence.*;
 
 import lombok.Data;
 
 import java.math.BigDecimal;
-
 
 @Data
 @Entity
@@ -29,4 +27,7 @@ public class ProdutoEntity {
     @ManyToOne
     @JoinColumn(name = "id_categoria", nullable = false)
     private CategoriaEntity categoria;
+
+    @Column(nullable = false)
+    private boolean ativo = true;
 }

--- a/src/main/java/br/com/fiap/lanchonete/infrastructure/adapters/repositories/ProdutoJpaRepository.java
+++ b/src/main/java/br/com/fiap/lanchonete/infrastructure/adapters/repositories/ProdutoJpaRepository.java
@@ -1,20 +1,27 @@
 package br.com.fiap.lanchonete.infrastructure.adapters.repositories;
 
-import br.com.fiap.lanchonete.infrastructure.adapters.entity.ProdutoEntity;
-import jakarta.transaction.Transactional;
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
-import java.util.Optional;
+import br.com.fiap.lanchonete.infrastructure.adapters.entity.CategoriaEntity;
+import br.com.fiap.lanchonete.infrastructure.adapters.entity.ProdutoEntity;
+import jakarta.transaction.Transactional;
 
 public interface ProdutoJpaRepository extends JpaRepository<ProdutoEntity, String> {
-    @Query("SELECT p FROM ProdutoEntity p WHERE p.idProduto = :idProduto")
+    @Query("SELECT p FROM ProdutoEntity p WHERE p.ativo = true and p.idProduto = :idProduto")
     Optional<ProdutoEntity> findByIdProduto(String idProduto);
 
     @Transactional
     @Modifying
-    @Query("DELETE FROM ProdutoEntity p WHERE p.idProduto = :idProduto")
+    @Query("UPDATE ProdutoEntity p SET p.ativo = false WHERE p.idProduto = :idProduto")
     void deleteByIdProduto(String idProduto);
+
+    List<ProdutoEntity> findAllByAtivoTrue();
+
+    List<ProdutoEntity> findAllByAtivoTrueAndCategoria(CategoriaEntity categoria);
 
 }

--- a/src/main/java/br/com/fiap/lanchonete/infrastructure/adapters/repositories/ProdutoRepositoryImp.java
+++ b/src/main/java/br/com/fiap/lanchonete/infrastructure/adapters/repositories/ProdutoRepositoryImp.java
@@ -2,6 +2,7 @@ package br.com.fiap.lanchonete.infrastructure.adapters.repositories;
 
 import br.com.fiap.lanchonete.domain.dtos.ProdutoDto;
 import br.com.fiap.lanchonete.domain.ports.repositories.ProdutoRepositoryPort;
+import br.com.fiap.lanchonete.infrastructure.adapters.entity.CategoriaEntity;
 import br.com.fiap.lanchonete.infrastructure.adapters.entity.ProdutoEntity;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,6 +10,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Repository
 public class ProdutoRepositoryImp implements ProdutoRepositoryPort {
@@ -44,6 +46,22 @@ public class ProdutoRepositoryImp implements ProdutoRepositoryPort {
     @Override
     public void deleteByIdProduto(String idProduto) {
         produtoJpaRepository.deleteByIdProduto(idProduto);
+    }
+
+    @Override
+    public List<ProdutoDto> findAllByAtivoTrue() {
+        return produtoJpaRepository.findAllByAtivoTrue()
+                .stream()
+                .map(entity -> modelMapper.map(entity, ProdutoDto.class))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<ProdutoDto> findAllByAtivoTrueAndCategoria(CategoriaEntity categoria) {
+        return produtoJpaRepository.findAllByAtivoTrueAndCategoria(categoria)
+                .stream()
+                .map(entity -> modelMapper.map(entity, ProdutoDto.class))
+                .collect(Collectors.toList());
     }
 
 }


### PR DESCRIPTION
Alterada a ação de exclusão para realizar um soft delete (atualizando o "ativo" para falso). Modificado o endpoint de listagem de todos os produtos, para listar apenas produtos ativos em "getAllProdutos". Implementado o endpoint de consulta de produtos por categoria, que lista todos os produtos ativos da categoria desejada. A consulta de produtos por ID não foi alterada, ou seja, ao pesquisar pelo ID o registro é retornado mesmo que esteja inativo.